### PR TITLE
Add MCP connections and tool toggling

### DIFF
--- a/app/api/realtime-token/route.ts
+++ b/app/api/realtime-token/route.ts
@@ -1,8 +1,16 @@
 export const runtime = 'edge';
 
-export async function GET() {
+async function createSession(overrides: any = {}) {
   const apiKey = process.env.OPENAI_API_KEY!;
   const model = process.env.OPENAI_REALTIME_MODEL || 'gpt-4o-realtime-preview';
+
+  const payload: Record<string, any> = {
+    model,
+    voice: 'verse',
+    modalities: ['audio', 'text'],
+    instructions: 'You are a concise Norwegian voice assistant.',
+    ...overrides,
+  };
 
   const r = await fetch('https://api.openai.com/v1/realtime/sessions', {
     method: 'POST',
@@ -10,17 +18,30 @@ export async function GET() {
       'Authorization': `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({
-      model,
-      voice: 'verse',
-      modalities: ['audio', 'text'],
-      instructions: 'You are a concise Norwegian voice assistant.',
-    }),
+    body: JSON.stringify(payload),
   });
 
   if (!r.ok) {
     return new Response(await r.text(), { status: r.status });
   }
   const json = await r.json();
-  return new Response(JSON.stringify(json), { headers: { 'Content-Type': 'application/json' } });
+  return new Response(JSON.stringify(json), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export async function POST(req: Request) {
+  try {
+    const { tools, connections } = await req.json();
+    const overrides: Record<string, any> = {};
+    if (connections) overrides.connections = connections;
+    if (Array.isArray(tools) && tools.length) overrides.tools = tools;
+    return createSession(overrides);
+  } catch {
+    return createSession();
+  }
+}
+
+export async function GET() {
+  return createSession();
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,12 +7,30 @@ export default function Home() {
   const [connected, setConnected] = useState(false);
   const [log, setLog] = useState<string[]>([]);
   const [speaking, setSpeaking] = useState(false);
+  const [useTools, setUseTools] = useState(false);
+  const [connections, setConnections] = useState('');
 
   async function connect() {
     if (pcRef.current) return;
 
     // 1) Hent ephemeral session fra vårt API
-    const session = await fetch('/api/realtime-token').then(r => r.json());
+    const body: Record<string, any> = {};
+    if (useTools) {
+      body.tools = [{ type: 'mcp', name: 'example' }];
+    }
+    if (connections) {
+      try {
+        body.connections = JSON.parse(connections);
+      } catch (e) {
+        console.error('Invalid connections JSON', e);
+      }
+    }
+
+    const session = await fetch('/api/realtime-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then(r => r.json());
 
     // 2) Opprett peer connection
     const pc = new RTCPeerConnection();
@@ -85,6 +103,22 @@ export default function Home() {
           >
             Stopp
           </button>
+        </div>
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={useTools}
+              onChange={(e) => setUseTools(e.target.checked)}
+            />
+            Aktiver tools
+          </label>
+          <textarea
+            className="w-full border rounded p-2 text-sm"
+            placeholder="Connections JSON"
+            value={connections}
+            onChange={(e) => setConnections(e.target.value)}
+          />
         </div>
         <p className="text-sm text-gray-600">
           Trykk <b>Start</b>, gi mic-tilgang og snakk. Modellen svarer med stemme i sanntid.


### PR DESCRIPTION
## Summary
- support POST requests for realtime tokens including MCP `connections` and `tools`
- add UI to specify connections and toggle tools on/off before starting a session

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: requires interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68b17d69d104832cb4b850457c8392ab